### PR TITLE
Document per-module CDN usage for Webflow

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -1,6 +1,6 @@
 # CSS Packages
 
-Each file in this folder is a self-contained module that mirrors a section of the provided stylesheet. Copy only the modules you need into Webflow so that edits stay isolated.
+Each file in this folder is a self-contained module that mirrors a section of the provided stylesheet. Reference only the modules you need inside Webflow so that edits stay isolated.
 
 - `vars-anchor.css` – Global CSS variables for the navigation component and anchor offset behavior.
 - `cad-grid.css` – CAD grid background helper classes and layering rules.
@@ -9,3 +9,22 @@ Each file in this folder is a self-contained module that mirrors a section of th
 - `nav.css` – Navigation pill layout, link styling, responsive tweaks, and JS-fallback states.
 - `bg-nonlinear.css` – Fixed soft grey background with animated drift.
 - `button-eclipse.css` – Eclipse hover effect for buttons and anchor buttons.
+
+## Using the modules in Webflow
+
+Add one `<link>` tag per module inside **Project Settings → Custom Code → Head**. This keeps the modules independent so you can deploy surgical updates without touching the others.
+
+```html
+<!-- Required shared variables -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/vars-anchor.css" />
+
+<!-- Optional modules (add/remove as needed) -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/nav.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/cad-grid.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/bg-nonlinear.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/reveal.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/wipe-heading.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/button-eclipse.css" />
+```
+
+Replace `USERNAME`, `REPO`, and `TAG` with your GitHub username, repository name, and release tag or branch (e.g. `@main`). Clear the Webflow published site cache if you update a file so jsDelivr serves the latest version.


### PR DESCRIPTION
## Summary
- update the README to explain how to include each CSS module individually via jsDelivr inside Webflow's head code
- remove the aggregated `webflow-bundle.css` so only the modular includes remain

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cbe2c58de48325b1fa0b9a433fe21b