### PR TITLE
Refine eclipse button hover effect

### DIFF
--- a/packages/button-eclipse.css
+++ b/packages/button-eclipse.css
@@ -1,25 +1,60 @@
 /* Button eclipse hover */
-a.btn, button, a[role="button"]{ position:relative; overflow:hidden; cursor:pointer; transition:color .4s ease; }
+@property --wave-progress {
+  syntax: '<number>';
+  inherits: false;
+  initial-value: 0;
+}
+
+a.btn, button, a[role="button"]{
+  position:relative;
+  overflow:hidden;
+  cursor:pointer;
+  --wave-progress:0;
+  --wave-duration:1.1s;
+  --wave-ease:cubic-bezier(.22,.61,.28,.99);
+  transition:color .4s ease, --wave-progress var(--wave-duration) var(--wave-ease);
+}
 a.btn{ --fill-to:#092a66; --text-hover:#fff; }
 .btn.is-primary, .btn.is-gold, a.btn[data-variant="gold"]{ --fill-to:#000; --text-hover:#FFD160; }
+
+a.btn::before, button::before, a[role="button"]::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  z-index:0;
+  background:var(--fill-to, #092a66);
+  transform-origin:left center;
+  transform:scaleX(var(--wave-progress));
+}
+
 a.btn::after, button::after, a[role="button"]::after{
-  content:""; position:absolute; inset:0; z-index:0;
+  content:"";
+  position:absolute;
+  top:50%;
+  left:calc(-30% + var(--wave-progress) * 160%);
+  width:160%;
+  aspect-ratio:1;
+  z-index:1;
+  transform:translate(-50%, -50%);
+  border-radius:50%;
   background:
-    radial-gradient(250px 250px at var(--spot-x, -300px) 50%, var(--fill-to, #092a66) 0 250px, transparent 255px),
-    radial-gradient(circle, rgba(255,255,255,.08) 1px, transparent 1px);
-  background-size:auto, 3px 3px; background-repeat:no-repeat, repeat;
-  opacity:0; transition:opacity .35s ease, filter .35s ease;
+    radial-gradient(circle at center, rgba(255,255,255,.26) 0 35%, rgba(255,255,255,0) 65%),
+    radial-gradient(circle at center, var(--fill-to, #092a66) 0 55%, transparent 75%);
+  background-repeat:no-repeat;
+  background-size:100% 100%;
+  opacity:clamp(0, calc(var(--wave-progress) * 1.3), 1);
+  filter:contrast(105%) saturate(102%);
 }
-a.btn > *, button > *, a[role="button"] > *{ position:relative; z-index:1; }
-a.btn:hover::after, button:hover::after, a[role="button"]:hover::after{
-  animation:spot-sweep 1200ms cubic-bezier(.22,.61,.28,.99) forwards;
-  opacity:1; filter:contrast(105%) saturate(102%);
-}
-@keyframes spot-sweep{
-  0% { --spot-x:-300px; }
-  35%{ --spot-x:28%; }
-  70%{ --spot-x:74%; }
-  100%{ --spot-x:calc(100% + 300px); }
+
+a.btn > *, button > *, a[role="button"] > *{ position:relative; z-index:2; }
+
+a.btn:hover, button:hover, a[role="button"]:hover{
+  --wave-progress:1;
 }
 a.btn:hover, a[role="button"]:hover{ color:var(--text-hover,#fff); }
 button:hover{ color:var(--text-hover,#FFD160); }
+
+@media (prefers-reduced-motion: reduce){
+  a.btn, button, a[role="button"]{ --wave-duration:0.01ms; }
+  a.btn::after, button::after, a[role="button"]::after{ opacity:0; }
+}


### PR DESCRIPTION
## Summary
- replace the radial-gradient hover effect with a two-layer before/after system that leaves behind a fill and pushes a circular wave across the button
- animate both layers with a shared --wave-progress custom property that eases in and out and resets smoothly
- respect prefers-reduced-motion by shortening the transition and hiding the moving wavefront

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cbefef86d8832598bf93c8db96a797