### PR TITLE
Automate bundle build timestamp update

### DIFF
--- a/.github/workflows/update-bundle-build.yml
+++ b/.github/workflows/update-bundle-build.yml
@@ -1,0 +1,70 @@
+name: Update bundle build stamp
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  update-bundle:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate UTC build stamp
+        id: stamp
+        run: echo "value=$(date -u '+%Y-%m-%d-%H%M')" >> "$GITHUB_OUTPUT"
+
+      - name: Update bundle.css with build stamp
+        env:
+          STAMP: ${{ steps.stamp.outputs.value }}
+        run: |
+          python <<'PY'
+          from pathlib import Path
+          import re
+          import os
+
+          stamp = os.environ['STAMP']
+          path = Path('packages/bundle.css')
+          text = path.read_text()
+
+          comment_pattern = re.compile(r'/\*!\s*SweQuant bundle\.css.*?\*/', re.S)
+          if comment_pattern.search(text):
+              text = comment_pattern.sub(f'/*! SweQuant bundle.css | build: {stamp} */', text, count=1)
+          else:
+              text = f'/*! SweQuant bundle.css | build: {stamp} */\n\n' + text.lstrip()
+
+          if re.search(r':root\s*\{\s*--sq-build:', text):
+              text = re.sub(r':root\s*\{\s*--sq-build:\s*"[^"]*"\s*;\s*\}', f':root {{ --sq-build: "{stamp}"; }}', text, count=1)
+          else:
+              text = text.rstrip() + f"\n\n/* build stamp */\n:root {{ --sq-build: \"{stamp}\"; }}\n"
+
+          path.write_text(text)
+          PY
+
+      - name: Commit changes
+        env:
+          STAMP: ${{ steps.stamp.outputs.value }}
+        run: |
+          if git diff --quiet -- packages/bundle.css; then
+            echo "bundle.css is already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packages/bundle.css
+          git commit -m "chore: update bundle build stamp ${STAMP}"
+          git push
+
+      - name: Purge jsDelivr cache
+        run: |
+          curl -sS "https://purge.jsdelivr.net/gh/SweQuant/site@main/packages/bundle.css" || true
+
+      - name: Publish build stamp
+        run: |
+          echo "### Latest bundle build" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Timestamp: ${{ steps.stamp.outputs.value }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- CDN URL: https://cdn.jsdelivr.net/gh/SweQuant/site@main/packages/bundle.css?v=${{ steps.stamp.outputs.value }}" >> "$GITHUB_STEP_SUMMARY"

--- a/packages/bundle.css
+++ b/packages/bundle.css
@@ -1,4 +1,4 @@
-/*! SweQuant bundle.css */
+/*! SweQuant bundle.css | build: 2025-09-18-1241 */
 
 @import "./vars-anchor.css";
 @import "./nav.css";
@@ -7,3 +7,6 @@
 @import "./reveal.css";
 @import "./wipe-heading.css";
 @import "./button-eclipse.css";
+
+/* build stamp */
+:root { --sq-build: "2025-09-18-1241"; }


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that rewrites packages/bundle.css with a fresh UTC build stamp, commits it, and purges jsDelivr
- ensure the bundle exports the sq-build custom property alongside the stamped header comment

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68cbfda5d5348325923c08b9217305f7