### PR TITLE
Adjust nav underline animation behavior

### DIFF
--- a/packages/bundle.css
+++ b/packages/bundle.css
@@ -61,20 +61,17 @@ html { scroll-padding-top: calc(var(--nav-top) + var(--nav-h) + 8px); }
 }
 .nav-links a::after{
   content:""; position:absolute; left:0; bottom:-6px; height:2px; width:100%;
-  background: currentColor; transform:scaleX(0); transform-origin:left;
-  transition: transform .35s cubic-bezier(.25,.55,.25,1);
+  background: currentColor; opacity:0; transform:scaleX(0); transform-origin:left;
+  transition: opacity .35s cubic-bezier(.25,.55,.25,1), transform .35s cubic-bezier(.25,.55,.25,1);
 }
-.nav-links a:hover,
-.nav-links a:focus-visible{
+.nav-links a:is(:hover, :focus-visible, :active){
   color:var(--nav-link-hover-color,#1c2a36);
 }
-.nav-links a:hover::after,
-.nav-links a:focus-visible::after{
-  transform:scaleX(1);
+.nav-links a:is(:hover, :focus-visible, :active)::after{
+  opacity:1; transform:scaleX(1);
 }
 .nav-links a:active{ transform:scale(.96); }
 .nav-links a.active{ color:var(--nav-link-color,#0f1720); font-weight:600; }
-.nav-links a.active::after{ transform:scaleX(1); }
 
 /* entrance */
 [data-nav-expand].in .nav-glass{ animation:nav-fade-in var(--dur,420ms) cubic-bezier(.25,.55,.25,1) forwards; animation-delay:var(--delay,140ms); }

--- a/packages/nav.css
+++ b/packages/nav.css
@@ -44,20 +44,17 @@
 }
 .nav-links a::after{
   content:""; position:absolute; left:0; bottom:-6px; height:2px; width:100%;
-  background: currentColor; transform:scaleX(0); transform-origin:left;
-  transition: transform .35s cubic-bezier(.25,.55,.25,1);
+  background: currentColor; opacity:0; transform:scaleX(0); transform-origin:left;
+  transition: opacity .35s cubic-bezier(.25,.55,.25,1), transform .35s cubic-bezier(.25,.55,.25,1);
 }
-.nav-links a:hover,
-.nav-links a:focus-visible{
+.nav-links a:is(:hover, :focus-visible, :active){
   color:var(--nav-link-hover-color,#1c2a36);
 }
-.nav-links a:hover::after,
-.nav-links a:focus-visible::after{
-  transform:scaleX(1);
+.nav-links a:is(:hover, :focus-visible, :active)::after{
+  opacity:1; transform:scaleX(1);
 }
 .nav-links a:active{ transform:scale(.96); }
 .nav-links a.active{ color:var(--nav-link-color,#0f1720); font-weight:600; }
-.nav-links a.active::after{ transform:scaleX(1); }
 
 /* entrance */
 [data-nav-expand].in .nav-glass{ animation:nav-fade-in var(--dur,420ms) cubic-bezier(.25,.55,.25,1) forwards; animation-delay:var(--delay,140ms); }


### PR DESCRIPTION
## Summary
- collapse the nav link underline by default and animate it on hover, focus, or press
- mirror the hover/press underline behavior update in the bundled stylesheet

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68cc22811fd48325bee23e5a923e2150