### PR TITLE
Make glass surface utility override designer backgrounds

### DIFF
--- a/packages/bundle.css
+++ b/packages/bundle.css
@@ -39,6 +39,18 @@ html { scroll-padding-top: calc(var(--nav-top) + var(--nav-h) + 8px); }
   box-shadow:none !important;
   transform:scaleX(.96); opacity:0;
 }
+.glass-surface {
+  background:
+    radial-gradient(120% 220% at 50% 50%,
+      rgba(255,255,255,.24) 0%,
+      rgba(255,255,255,.20) 55%,
+      rgba(255,255,255,.16) 80%,
+      rgba(255,255,255,.08) 100%) !important;
+  border: 1px solid rgba(255,255,255,.32) !important;
+  backdrop-filter: blur(1.6px) saturate(160%) !important;
+  -webkit-backdrop-filter: blur(1.6px) saturate(160%) !important;
+  border-radius: 18px;
+}
 .nav-items{ display:flex; align-items:center; gap:12px; width:100%; opacity:0; transform:translateY(4px); filter:blur(1px); }
 .nav-logo{ display:flex; align-items:center; }
 .nav-logo img{ display:block; height:var(--logo-h,48px); width:auto; max-height:none; }


### PR DESCRIPTION
## Summary
- strengthen the `.glass-surface` utility so its blur, gradient, and border win against Webflow designer styling by default

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ccf96aece08325ace4b87950a64ca0