### PR TITLE
Add glass surface module to bundle

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -10,6 +10,7 @@ If you prefer to load a single stylesheet, use `bundle.css`. It contains every m
 - `reveal.css` – Scroll reveal animation utilities and reduced motion fallback.
 - `wipe-heading.css` – Word-by-word wipe animation for headings.
 - `nav.css` – Navigation pill layout, link styling, responsive tweaks, and JS-fallback states.
+- `glass-surface.css` – Reusable frosted glass background, blur, and border utility.
 - `bg-nonlinear.css` – Fixed soft grey background with animated drift.
 - `button-eclipse.css` – Eclipse hover effect for buttons and anchor buttons.
 
@@ -65,6 +66,10 @@ ln -sf ../../scripts/git-hooks/post-merge .git/hooks/post-merge
 ```
 
 The hook simply calls `node scripts/build-bundle.js auto`, so every merge updates `packages/bundle.css` with a fresh stamp ready for publishing.
+
+### Adding new CSS modules
+
+When you introduce a fresh chunk of CSS, drop it in its own file inside this directory and add the filename to the `modules` array in `scripts/build-bundle.js`. Regenerate `bundle.css` with the build script afterwards so the bundle stays in sync with the standalone modules.
 
 ### Recommended Webflow head snippet
 

--- a/packages/bundle.css
+++ b/packages/bundle.css
@@ -1,7 +1,7 @@
-/*! SweQuant bundle.css | build: 2025-09-18-1704 */
+/*! SweQuant bundle.css | build: 001202509190909 */
 
 /* build stamp */
-:root { --sq-build: "2025-09-18-1704"; }
+:root { --sq-build: "001202509190909"; }
 
 /* === vars-anchor.css === */
 /* Vars & anchor offset */
@@ -94,6 +94,21 @@ html { scroll-padding-top: calc(var(--nav-top) + var(--nav-h) + 8px); }
 .nav-items{ opacity:1; transform:none; filter:none; }
 [data-nav-expand].is-animating .nav-glass{ opacity:0; transform:scaleX(.96); }
 [data-nav-expand].is-animating .nav-items{ opacity:0; transform:translateY(4px); filter:blur(1px); }
+
+/* === glass-surface.css === */
+/* Glass surface utility */
+.glass-surface{
+  background:
+    radial-gradient(120% 220% at 50% 50%,
+      rgba(255,255,255,.24) 0%,
+      rgba(255,255,255,.20) 55%,
+      rgba(255,255,255,.16) 80%,
+      rgba(255,255,255,.08) 100%) !important;
+  border:1px solid rgba(255,255,255,.32) !important;
+  backdrop-filter: blur(1.6px) saturate(160%) !important;
+  -webkit-backdrop-filter: blur(1.6px) saturate(160%) !important;
+  border-radius:18px;
+}
 
 /* === cad-grid.css === */
 /* CAD grid host stays behind content */

--- a/packages/glass-surface.css
+++ b/packages/glass-surface.css
@@ -1,0 +1,13 @@
+/* Glass surface utility */
+.glass-surface{
+  background:
+    radial-gradient(120% 220% at 50% 50%,
+      rgba(255,255,255,.24) 0%,
+      rgba(255,255,255,.20) 55%,
+      rgba(255,255,255,.16) 80%,
+      rgba(255,255,255,.08) 100%) !important;
+  border:1px solid rgba(255,255,255,.32) !important;
+  backdrop-filter: blur(1.6px) saturate(160%) !important;
+  -webkit-backdrop-filter: blur(1.6px) saturate(160%) !important;
+  border-radius:18px;
+}

--- a/scripts/build-bundle.js
+++ b/scripts/build-bundle.js
@@ -5,6 +5,7 @@ const path = require('path');
 const modules = [
   'vars-anchor.css',
   'nav.css',
+  'glass-surface.css',
   'cad-grid.css',
   'bg-nonlinear.css',
   'reveal.css',


### PR DESCRIPTION
## Summary
- move the glass surface utility into its own CSS module and expose it for reuse
- include the new module in the bundle builder so the compiled stylesheet stays in sync
- document the new module list and spell out the process for adding future CSS packages

## Testing
- node scripts/build-bundle.js auto

------
https://chatgpt.com/codex/tasks/task_b_68ccf96aece08325ace4b87950a64ca0