### PR TITLE
Scope nav fallback to no-js root

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -17,6 +17,22 @@ If you prefer to load a single stylesheet, use `bundle.css`. It contains every m
 
 Add one `<link>` tag per module inside **Project Settings → Custom Code → Head**. This keeps the modules independent so you can deploy surgical updates without touching the others.
 
+When you use the navigation module, add a `.no-js` class to the root element so the fallback styles only apply when scripting is unavailable. Remove the class in the very first inline script block so JavaScript-driven entrance animations can take over immediately after the HTML loads.
+
+```html
+<html class="no-js">
+  <head>
+    <script>
+      document.documentElement.classList.remove('no-js');
+    </script>
+    <!-- link tags continue here -->
+  </head>
+  <body>
+    <!-- page markup -->
+  </body>
+</html>
+```
+
 ```html
 <!-- Required shared variables -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/vars-anchor.css" />

--- a/packages/bundle.css
+++ b/packages/bundle.css
@@ -103,10 +103,10 @@ html { scroll-padding-top: calc(var(--nav-top) + var(--nav-h) + 8px); }
 }
 
 /* Safety: ensure nav shows even if JS fails */
-.nav-glass{ opacity:1; transform:none; }
-.nav-items{ opacity:1; transform:none; filter:none; }
-[data-nav-expand].is-animating .nav-glass{ opacity:0; transform:scaleX(.96); }
-[data-nav-expand].is-animating .nav-items{ opacity:0; transform:translateY(4px); filter:blur(1px); }
+.no-js [data-nav-expand] .nav-glass{ opacity:1; transform:none; }
+.no-js [data-nav-expand] .nav-items{ opacity:1; transform:none; filter:none; }
+.no-js [data-nav-expand].is-animating .nav-glass{ opacity:0; transform:scaleX(.96); }
+.no-js [data-nav-expand].is-animating .nav-items{ opacity:0; transform:translateY(4px); filter:blur(1px); }
 
 /* === cad-grid.css === */
 /* CAD grid host stays behind content */

--- a/packages/nav.css
+++ b/packages/nav.css
@@ -86,7 +86,7 @@
 }
 
 /* Safety: ensure nav shows even if JS fails */
-.nav-glass{ opacity:1; transform:none; }
-.nav-items{ opacity:1; transform:none; filter:none; }
-[data-nav-expand].is-animating .nav-glass{ opacity:0; transform:scaleX(.96); }
-[data-nav-expand].is-animating .nav-items{ opacity:0; transform:translateY(4px); filter:blur(1px); }
+.no-js [data-nav-expand] .nav-glass{ opacity:1; transform:none; }
+.no-js [data-nav-expand] .nav-items{ opacity:1; transform:none; filter:none; }
+.no-js [data-nav-expand].is-animating .nav-glass{ opacity:0; transform:scaleX(.96); }
+.no-js [data-nav-expand].is-animating .nav-items{ opacity:0; transform:translateY(4px); filter:blur(1px); }


### PR DESCRIPTION
## Summary
- scope the navigation fallback selectors so they only fire when a `.no-js` root class is present
- mirror the scoped fallback inside the packaged CDN bundle and document how to toggle the class in markup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68cdb158233c83258737fbc5e0ad2c2f