### PR TITLE
Add wipe heading chunk helper and animation support

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -43,6 +43,7 @@ When you use the navigation module, add a `.no-js` class to the root element so 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/bg-nonlinear.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/reveal.css" />
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/wipe-heading.css" />
+<script defer src="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/wipe-heading.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/button-eclipse.css" />
 
 <!-- Or load everything at once -->
@@ -58,6 +59,16 @@ To enable the animated CAD background, load the standalone script and make sure 
 ```
 
 The script auto-initialises on `DOMContentLoaded`, so no inline bootstrapping code is required.
+
+### Wipe heading animation helper
+
+The chunking helper scans every `[data-wipe-words]` element, preserves the original label for screen readers, and wraps the text in `.wipe-chunk` spans so each chunk can animate with a staggered delay.
+
+```html
+<script defer src="https://cdn.jsdelivr.net/gh/USERNAME/REPO@TAG/packages/wipe-heading.js"></script>
+```
+
+Include the script once per page, ideally alongside the stylesheet link in the global head snippet.
 
 ### Maintaining the bundle build stamp
 

--- a/packages/bundle.css
+++ b/packages/bundle.css
@@ -1,8 +1,8 @@
 <style>
-/*! SweQuant bundle.css | build: 2025-09-19-1944 */
+/*! SweQuant bundle.css | build: 001202509192216 */
 
 /* build stamp */
-:root { --sq-build: "2025-09-19-1944"; }
+:root { --sq-build: "001202509192216"; }
 
 /* === vars-anchor.css === */
 /* Vars & anchor offset */
@@ -153,6 +153,13 @@ html { scroll-padding-top: calc(var(--nav-top) + var(--nav-h) + 8px); }
 .wipe-word.in .wipe-inner{
   animation:wipe-rise var(--wipe-dur,900ms) cubic-bezier(.25,.55,.25,1) forwards;
   animation-delay:calc(var(--d,0ms) + var(--lead,160ms));
+}
+.wipe-word--chunked .wipe-inner{ display:inline-flex; transform:none; opacity:1; will-change:auto; }
+.wipe-word--chunked.in .wipe-inner{ animation:none; }
+.wipe-word--chunked .wipe-chunk{ display:inline-block; transform:translateY(110%); opacity:.001; will-change:transform,opacity; }
+.wipe-word--chunked.in .wipe-chunk{
+  animation:wipe-rise var(--wipe-dur,900ms) cubic-bezier(.25,.55,.25,1) forwards;
+  animation-delay:calc(var(--d,0ms) + var(--lead,160ms) + var(--i) * var(--step,50ms));
 }
 @keyframes wipe-rise{ 0%{transform:translateY(110%);opacity:.001} 65%{transform:translateY(0);opacity:1} 100%{transform:translateY(0);opacity:1} }
 [data-wipe-words].reveal{ opacity:1; transform:none; filter:none; }

--- a/packages/wipe-heading.css
+++ b/packages/wipe-heading.css
@@ -6,5 +6,12 @@
   animation:wipe-rise var(--wipe-dur,900ms) cubic-bezier(.25,.55,.25,1) forwards;
   animation-delay:calc(var(--d,0ms) + var(--lead,160ms));
 }
+.wipe-word--chunked .wipe-inner{ display:inline-flex; transform:none; opacity:1; will-change:auto; }
+.wipe-word--chunked.in .wipe-inner{ animation:none; }
+.wipe-word--chunked .wipe-chunk{ display:inline-block; transform:translateY(110%); opacity:.001; will-change:transform,opacity; }
+.wipe-word--chunked.in .wipe-chunk{
+  animation:wipe-rise var(--wipe-dur,900ms) cubic-bezier(.25,.55,.25,1) forwards;
+  animation-delay:calc(var(--d,0ms) + var(--lead,160ms) + var(--i) * var(--step,50ms));
+}
 @keyframes wipe-rise{ 0%{transform:translateY(110%);opacity:.001} 65%{transform:translateY(0);opacity:1} 100%{transform:translateY(0);opacity:1} }
 [data-wipe-words].reveal{ opacity:1; transform:none; filter:none; }

--- a/packages/wipe-heading.js
+++ b/packages/wipe-heading.js
@@ -1,0 +1,81 @@
+(function(){
+  const SELECTOR = '[data-wipe-words]';
+
+  const splitIntoChunks = (token) => {
+    const chunks = [];
+    let index = 0;
+    while (index < token.length) {
+      const remaining = token.length - index;
+      let size = remaining > 3 ? 3 : remaining;
+      if (remaining === 4) {
+        size = 2;
+      }
+      chunks.push(token.slice(index, index + size));
+      index += size;
+    }
+    return chunks;
+  };
+
+  const processElement = (element) => {
+    if (!element || element.dataset.wipeProcessed === 'true') {
+      return;
+    }
+
+    const originalText = element.textContent || '';
+    const readableLabel = originalText.replace(/\s+/g, ' ').trim();
+
+    if (readableLabel) {
+      element.setAttribute('aria-label', readableLabel);
+    } else {
+      element.removeAttribute('aria-label');
+    }
+
+    element.dataset.wipeProcessed = 'true';
+    element.setAttribute('data-wipe-original', originalText);
+    element.textContent = '';
+
+    const tokens = originalText.split(/(\s+)/);
+    let chunkIndex = 0;
+
+    tokens.forEach((token) => {
+      if (!token) {
+        return;
+      }
+
+      if (/^\s+$/.test(token)) {
+        element.appendChild(document.createTextNode(token));
+        return;
+      }
+
+      const word = document.createElement('span');
+      word.className = 'wipe-word';
+      word.setAttribute('aria-hidden', 'true');
+
+      const inner = document.createElement('span');
+      inner.className = 'wipe-inner wipe-inner--chunked';
+
+      splitIntoChunks(token).forEach((chunk) => {
+        const chunkEl = document.createElement('span');
+        chunkEl.className = 'wipe-chunk';
+        chunkEl.textContent = chunk;
+        chunkEl.style.setProperty('--i', String(chunkIndex));
+        inner.appendChild(chunkEl);
+        chunkIndex += 1;
+      });
+
+      word.classList.add('wipe-word--chunked');
+      word.appendChild(inner);
+      element.appendChild(word);
+    });
+  };
+
+  const init = () => {
+    document.querySelectorAll(SELECTOR).forEach(processElement);
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary
- add a helper script that chunks `[data-wipe-words]` headings into animated spans and preserves accessible labels
- extend the wipe heading styles to drive staggered chunk animations and refresh the aggregated bundle
- document the new script in the Webflow snippet so the helper loads alongside the stylesheet

## Testing
- node scripts/build-bundle.js auto

------
https://chatgpt.com/codex/tasks/task_b_68cdb965ff688325ab006b52249bd0b5