### PR TITLE
Allow reveal duration to be customized

### DIFF
--- a/packages/reveal.css
+++ b/packages/reveal.css
@@ -1,7 +1,7 @@
 /* Block reveal */
 .reveal,.reveal-btn{ opacity:0; transform:translateY(10px); filter:blur(2px); }
-.reveal.in{ animation:rise 560ms cubic-bezier(.25,.55,.25,1) forwards; animation-delay:var(--d,0ms); }
-.reveal-btn.in{ animation:rise 700ms cubic-bezier(.25,.55,.25,1) forwards; animation-delay:var(--d,0ms); }
+.reveal.in{ animation-name:rise; animation-duration:var(--dur,560ms); animation-timing-function:cubic-bezier(.25,.55,.25,1); animation-fill-mode:forwards; animation-delay:var(--d,0ms); }
+.reveal-btn.in{ animation-name:rise; animation-duration:var(--dur,700ms); animation-timing-function:cubic-bezier(.25,.55,.25,1); animation-fill-mode:forwards; animation-delay:var(--d,0ms); }
 .reveal-btn.in:hover{ transform:translateY(-1px) scale(1.01); }
 @keyframes rise{ from{opacity:0;transform:translateY(10px);filter:blur(2px)} to{opacity:1;transform:translateY(0);filter:blur(0)} }
 @media (prefers-reduced-motion:reduce){


### PR DESCRIPTION
## Summary
- use animation-duration custom properties on reveal transitions so controllers can set durations
- keep default timings for reveals and buttons via CSS fallbacks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cdd88fe508832585eff837008e625e